### PR TITLE
docs(code_executor): fix duplicated-words docstring

### DIFF
--- a/backend/code_executor.py
+++ b/backend/code_executor.py
@@ -1,4 +1,4 @@
-"""Code executor code_executor for Micro Plutoscope."""
+"""Code execution engine for Micro Plutoscope."""
 import sys
 from io import StringIO
 from ._base import SingletonMeta


### PR DESCRIPTION
## Summary

\`backend/code_executor.py\` module docstring had duplicated words:

Before:
\`\`\`
\"\"\"Code executor code_executor for Micro Plutoscope.\"\"\"
\`\`\`

After:
\`\`\`
\"\"\"Code execution engine for Micro Plutoscope.\"\"\"
\`\`\`

Closes #12

## Testing

Docstring-only change.