### PR TITLE
fix: correct docstring typo in code_executor.py

### DIFF
--- a/backend/code_executor.py
+++ b/backend/code_executor.py
@@ -1,4 +1,4 @@
-"""Code executor code_executor for Micro Plutoscope."""
+"""Code execution engine for Micro Plutoscope."""
 import sys
 from io import StringIO
 from ._base import SingletonMeta


### PR DESCRIPTION
## Summary
Fix docstring typo identified in issue #12:

**Before:** `Code executor code_executor for Micro Plutoscope.`
**After:** `Code execution engine for Micro Plutoscope.`

The module docstring had redundant wording `code executor code_executor` which should be `Code execution engine`.

Fixes #12