### PR TITLE
fix: correct docstring typo in code_executor.py

### DIFF
--- a/backend/code_executor.py
+++ b/backend/code_executor.py
@@ -1,4 +1,4 @@
-"""Code executor code_executor for Micro Plutoscope."""
+"""Code execution engine for Micro Plutoscope."""
 import sys
 from io import StringIO
 from ._base import SingletonMeta


### PR DESCRIPTION
Fix docstring typo in `backend/code_executor.py` line 1 (issue #12)

Replace redundant 'Code executor code_executor' with 'Code execution engine'.

Surgical 1-line fix. Single commit. No other changes.